### PR TITLE
Library update to support new Catalog navigation

### DIFF
--- a/Poushec.UpdateCatalogParser/CatalogClient.cs
+++ b/Poushec.UpdateCatalogParser/CatalogClient.cs
@@ -60,7 +60,7 @@ namespace Poushec.UpdateCatalogParser
             _pageReloadAttempts = pageReloadAttemptsAllowed;
             _catalogParser = new CatalogParser(client, cultureInfo);
         }
-        
+
         /// <summary>
         /// Sends search query to <see href="https://catalog.update.microsoft.com">catalog.update.microsoft.com</see>
         /// </summary>
@@ -73,19 +73,21 @@ namespace Poushec.UpdateCatalogParser
         /// <param name="sortDirection">(Optional) Sets the sort direction</param>
         /// <returns><see cref="CatalogSearchResult"/> list representing the search results</returns>
         public async Task<List<CatalogSearchResult>> SendSearchQueryAsync(
-            string Query, 
-            bool ignoreDuplicates = false, 
-            SortBy sortBy = SortBy.None, 
+            string Query,
+            bool ignoreDuplicates = false,
+            SortBy sortBy = SortBy.None,
             SortDirection sortDirection = SortDirection.Descending,
             CancellationToken cancellationToken = default
         )
         {
+            string sortQuery = ConstructSortQuery(sortBy, sortDirection);
+
             string catalogBaseUrl = "https://www.catalog.update.microsoft.com/Search.aspx";
-            string searchQueryUrl = String.Format($"{catalogBaseUrl}?q={UrlEncode(Query)}");
+            string searchQueryUrl = String.Format($"{catalogBaseUrl}?q={UrlEncode(Query)}{sortQuery}");
 
             CatalogResponse lastCatalogResponse = null;
             byte pageReloadAttemptsLeft = _pageReloadAttempts;
-            
+
             while (lastCatalogResponse is null)
             {
                 if (pageReloadAttemptsLeft == 0)
@@ -117,18 +119,20 @@ namespace Poushec.UpdateCatalogParser
                 }
             }
 
-            if (sortBy != SortBy.None)
-            {
-                // This will sort results in the ascending order
-                lastCatalogResponse = await SortSearchResultsAsync(Query, lastCatalogResponse, sortBy, cancellationToken);
-            
-                if (sortDirection is SortDirection.Descending)
-                {
-                    // The only way to sort results in the descending order is to send the same request again 
-                    lastCatalogResponse = await SortSearchResultsAsync(Query, lastCatalogResponse, sortBy, cancellationToken);
-                }
-            }
-            
+            lastCatalogResponse.SortQuery = sortQuery;
+
+            //if (sortBy != SortBy.None)
+            //{
+            //    // This will sort results in the ascending order
+            //    lastCatalogResponse = await SortSearchResultsAsync(Query, lastCatalogResponse, sortBy, cancellationToken);
+
+            //    if (sortDirection is SortDirection.Descending)
+            //    {
+            //        // The only way to sort results in the descending order is to send the same request again 
+            //        lastCatalogResponse = await SortSearchResultsAsync(Query, lastCatalogResponse, sortBy, cancellationToken);
+            //    }
+            //}
+
             List<CatalogSearchResult> searchResults = lastCatalogResponse.SearchResults;
             pageReloadAttemptsLeft = _pageReloadAttempts;
 
@@ -145,7 +149,7 @@ namespace Poushec.UpdateCatalogParser
                     searchResults.AddRange(lastCatalogResponse.SearchResults);
                     pageReloadAttemptsLeft = _pageReloadAttempts; // Reset page refresh attempts count
                 }
-                catch (TaskCanceledException) 
+                catch (TaskCanceledException)
                 {
                     // Request timed out - it happens
                     pageReloadAttemptsLeft--;
@@ -183,18 +187,20 @@ namespace Poushec.UpdateCatalogParser
         /// <param name="sortDirection">Sorting direction. <see cref="SortDirection.Ascending">Ascending</see> or <see cref="SortDirection.Descending">Descending</see></param>
         /// <returns><see cref="CatalogResponse"/> object representing the first results page</returns>
         public async Task<CatalogResponse> GetFirstPageFromSearchQueryAsync(
-            string Query, 
-            SortBy sortBy = SortBy.None, 
+            string Query,
+            SortBy sortBy = SortBy.None,
             SortDirection sortDirection = SortDirection.Descending,
             CancellationToken cancellationToken = default
         )
         {
+            string sortQuery = ConstructSortQuery(sortBy, sortDirection);
+
             string catalogBaseUrl = "https://www.catalog.update.microsoft.com/Search.aspx";
-            string searchQueryUrl = String.Format($"{catalogBaseUrl}?q={UrlEncode(Query)}"); 
-            
+            string searchQueryUrl = String.Format($"{catalogBaseUrl}?q={UrlEncode(Query)}{sortQuery}");
+
             CatalogResponse catalogFirstPage = null;
             byte pageReloadAttemptsLeft = _pageReloadAttempts;
-            
+
             while (catalogFirstPage is null)
             {
                 if (pageReloadAttemptsLeft == 0)
@@ -221,17 +227,19 @@ namespace Poushec.UpdateCatalogParser
                 }
             }
 
-            if (sortBy != SortBy.None)
-            {
-                // This will sort results in the ascending order
-                catalogFirstPage = await SortSearchResultsAsync(Query, catalogFirstPage, sortBy);
-            
-                if (sortDirection is SortDirection.Descending)
-                {
-                    // The only way to sort results in the descending order is to send the same request again 
-                    catalogFirstPage = await SortSearchResultsAsync(Query, catalogFirstPage, sortBy);
-                }
-            }
+            catalogFirstPage.SortQuery = sortQuery;
+
+            //if (sortBy != SortBy.None)
+            //{
+            //    // This will sort results in the ascending order
+            //    catalogFirstPage = await SortSearchResultsAsync(Query, catalogFirstPage, sortBy);
+
+            //    if (sortDirection is SortDirection.Descending)
+            //    {
+            //        // The only way to sort results in the descending order is to send the same request again 
+            //        catalogFirstPage = await SortSearchResultsAsync(Query, catalogFirstPage, sortBy);
+            //    }
+            //}
 
             return catalogFirstPage;
         }
@@ -248,18 +256,7 @@ namespace Poushec.UpdateCatalogParser
                 throw new CatalogNoResultsException("No more search results available. This is a final page.");
             }
 
-            //var formData = new Dictionary<string, string>() 
-            //{
-            //    { "__EVENTTARGET",          "ctl00$catalogBody$nextPageLinkText" },
-            //    { "__EVENTARGUMENT",        currentPage.EventArgument },
-            //    { "__VIEWSTATE",            currentPage.ViewState },
-            //    { "__VIEWSTATEGENERATOR",   currentPage.ViewStateGenerator },
-            //    { "__EVENTVALIDATION",      currentPage.EventValidation }
-            //};
-
-            //var requestContent = new FormUrlEncodedContent(formData); 
-
-            string nextPageUrl = $"{currentPage.SearchQueryUri}&p={currentPage.CurrentPage + 1}";
+            string nextPageUrl = $"{currentPage.SearchQueryUri}&p={currentPage.CurrentPage + 1}{currentPage.SortQuery}";
 
             HttpResponseMessage response = await _client.GetAsync(nextPageUrl, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -272,8 +269,7 @@ namespace Poushec.UpdateCatalogParser
                 return _catalogParser.ParseSearchResultsPage(HtmlDoc, currentPage.SearchQueryUri);
             }
         }
-        
-        
+
         /// <summary>
         /// Attempts to collect update details from Update Details Page and Download Page 
         /// </summary>
@@ -309,7 +305,7 @@ namespace Poushec.UpdateCatalogParser
 
             while (true)
             {
-                try 
+                try
                 {
                     detailsPage = await _catalogParser.LoadDetailsPageAsync(searchResult.UpdateID, cancellationToken);
                     break;
@@ -341,52 +337,12 @@ namespace Poushec.UpdateCatalogParser
 
             return updateBase;
         }
-        
-        private async Task<CatalogResponse> SortSearchResultsAsync(
-            string searchQuery, 
-            CatalogResponse unsortedResponse, 
-            SortBy sortBy, 
-            CancellationToken cancellationToken = default
-        )
-        {
-            string eventTarget = "ctl00$catalogBody$updateMatches$ctl02$";
-
-            switch (sortBy)
-            {
-                case SortBy.Title:           eventTarget += "titleHeaderLink"; break;
-                case SortBy.Products:        eventTarget += "productsHeaderLink"; break;
-                case SortBy.Classification:  eventTarget += "classHeaderLink"; break;
-                case SortBy.LastUpdated:     eventTarget += "dateHeaderLink"; break;
-                case SortBy.Version:         eventTarget += "versionHeaderLink"; break;
-                case SortBy.Size:            eventTarget += "sizeHeaderLink"; break;
-            }
-
-            var formData = new Dictionary<string, string>() 
-            {
-                { "__EVENTTARGET",          eventTarget },
-                { "__EVENTARGUMENT",        unsortedResponse.EventArgument },
-                { "__VIEWSTATE",            unsortedResponse.ViewState },
-                { "__VIEWSTATEGENERATOR",   unsortedResponse.ViewStateGenerator },
-                { "__EVENTVALIDATION",      unsortedResponse.EventValidation },
-                { "ctl00$searchTextBox",    searchQuery }
-            };
-
-            var requestContent = new FormUrlEncodedContent(formData); 
-
-            HttpResponseMessage response = await _client.PostAsync(unsortedResponse.SearchQueryUri, requestContent, cancellationToken);
-            response.EnsureSuccessStatusCode();
-            
-            var HtmlDoc = new HtmlDocument();
-            HtmlDoc.Load(await response.Content.ReadAsStreamAsync());
-
-            return _catalogParser.ParseSearchResultsPage(HtmlDoc, unsortedResponse.SearchQueryUri);
-        }
 
         private async Task<CatalogResponse> InternalSendSearchQueryAsync(string requestUri, CancellationToken cancellationToken)
         {
             HttpResponseMessage response = await _client.GetAsync(requestUri, cancellationToken);
             response.EnsureSuccessStatusCode();
-            
+
             var HtmlDoc = new HtmlDocument();
             HtmlDoc.Load(await response.Content.ReadAsStreamAsync());
 
@@ -396,6 +352,30 @@ namespace Poushec.UpdateCatalogParser
             }
 
             return _catalogParser.ParseSearchResultsPage(HtmlDoc, requestUri);
+        }
+
+        private string ConstructSortQuery(SortBy sortBy, SortDirection sortDirection)
+        {
+            if (sortBy == SortBy.None)
+            {
+                return string.Empty;
+            }
+
+            string columnName = string.Empty;
+
+            switch (sortBy)
+            {
+                case SortBy.Title: columnName = "Title"; break;
+                case SortBy.Products: columnName = "Products"; break;
+                case SortBy.Classification: columnName = "ClassificationComputed"; break;
+                case SortBy.LastUpdated: columnName = "DateComputed"; break;
+                case SortBy.Version: columnName = "DriverVerVersion"; break;
+                case SortBy.Size: columnName = "SizeInBytes"; break;
+            }
+
+            string sortDirectionQuery = sortDirection == SortDirection.Descending ? "desc" : "asc";
+
+            return $"&scol={columnName}&sdir={sortDirectionQuery}";
         }
     }
 }

--- a/Poushec.UpdateCatalogParser/CatalogClient.cs
+++ b/Poushec.UpdateCatalogParser/CatalogClient.cs
@@ -131,7 +131,7 @@ namespace Poushec.UpdateCatalogParser
             
             List<CatalogSearchResult> searchResults = lastCatalogResponse.SearchResults;
             pageReloadAttemptsLeft = _pageReloadAttempts;
-            
+
             while (!lastCatalogResponse.FinalPage)
             {
                 if (pageReloadAttemptsLeft == 0)
@@ -248,24 +248,29 @@ namespace Poushec.UpdateCatalogParser
                 throw new CatalogNoResultsException("No more search results available. This is a final page.");
             }
 
-            var formData = new Dictionary<string, string>() 
-            {
-                { "__EVENTTARGET",          "ctl00$catalogBody$nextPageLinkText" },
-                { "__EVENTARGUMENT",        currentPage.EventArgument },
-                { "__VIEWSTATE",            currentPage.ViewState },
-                { "__VIEWSTATEGENERATOR",   currentPage.ViewStateGenerator },
-                { "__EVENTVALIDATION",      currentPage.EventValidation }
-            };
+            //var formData = new Dictionary<string, string>() 
+            //{
+            //    { "__EVENTTARGET",          "ctl00$catalogBody$nextPageLinkText" },
+            //    { "__EVENTARGUMENT",        currentPage.EventArgument },
+            //    { "__VIEWSTATE",            currentPage.ViewState },
+            //    { "__VIEWSTATEGENERATOR",   currentPage.ViewStateGenerator },
+            //    { "__EVENTVALIDATION",      currentPage.EventValidation }
+            //};
 
-            var requestContent = new FormUrlEncodedContent(formData); 
+            //var requestContent = new FormUrlEncodedContent(formData); 
 
-            HttpResponseMessage response = await _client.PostAsync(currentPage.SearchQueryUri, requestContent, cancellationToken);
+            string nextPageUrl = $"{currentPage.SearchQueryUri}&p={currentPage.CurrentPage + 1}";
+
+            HttpResponseMessage response = await _client.GetAsync(nextPageUrl, cancellationToken);
             response.EnsureSuccessStatusCode();
-            
-            var HtmlDoc = new HtmlDocument();
-            HtmlDoc.Load(await response.Content.ReadAsStreamAsync());
 
-            return _catalogParser.ParseSearchResultsPage(HtmlDoc, currentPage.SearchQueryUri);
+            using (var responseStream = await response.Content.ReadAsStreamAsync())
+            {
+                var HtmlDoc = new HtmlDocument();
+                HtmlDoc.Load(await response.Content.ReadAsStreamAsync());
+
+                return _catalogParser.ParseSearchResultsPage(HtmlDoc, currentPage.SearchQueryUri);
+            }
         }
         
         

--- a/Poushec.UpdateCatalogParser/CatalogClient.cs
+++ b/Poushec.UpdateCatalogParser/CatalogClient.cs
@@ -251,21 +251,21 @@ namespace Poushec.UpdateCatalogParser
             var formData = new Dictionary<string, string>() 
             {
                 { "__EVENTTARGET",          "ctl00$catalogBody$nextPageLinkText" },
-                { "__EVENTARGUMENT",        currentPage._eventArgument },
-                { "__VIEWSTATE",            currentPage._viewState },
-                { "__VIEWSTATEGENERATOR",   currentPage._viewStateGenerator },
-                { "__EVENTVALIDATION",      currentPage._eventValidation }
+                { "__EVENTARGUMENT",        currentPage.EventArgument },
+                { "__VIEWSTATE",            currentPage.ViewState },
+                { "__VIEWSTATEGENERATOR",   currentPage.ViewStateGenerator },
+                { "__EVENTVALIDATION",      currentPage.EventValidation }
             };
 
             var requestContent = new FormUrlEncodedContent(formData); 
 
-            HttpResponseMessage response = await _client.PostAsync(currentPage._searchQueryUri, requestContent, cancellationToken);
+            HttpResponseMessage response = await _client.PostAsync(currentPage.SearchQueryUri, requestContent, cancellationToken);
             response.EnsureSuccessStatusCode();
             
             var HtmlDoc = new HtmlDocument();
             HtmlDoc.Load(await response.Content.ReadAsStreamAsync());
 
-            return _catalogParser.ParseSearchResultsPage(HtmlDoc, currentPage._searchQueryUri);
+            return _catalogParser.ParseSearchResultsPage(HtmlDoc, currentPage.SearchQueryUri);
         }
         
         
@@ -359,22 +359,22 @@ namespace Poushec.UpdateCatalogParser
             var formData = new Dictionary<string, string>() 
             {
                 { "__EVENTTARGET",          eventTarget },
-                { "__EVENTARGUMENT",        unsortedResponse._eventArgument },
-                { "__VIEWSTATE",            unsortedResponse._viewState },
-                { "__VIEWSTATEGENERATOR",   unsortedResponse._viewStateGenerator },
-                { "__EVENTVALIDATION",      unsortedResponse._eventValidation },
+                { "__EVENTARGUMENT",        unsortedResponse.EventArgument },
+                { "__VIEWSTATE",            unsortedResponse.ViewState },
+                { "__VIEWSTATEGENERATOR",   unsortedResponse.ViewStateGenerator },
+                { "__EVENTVALIDATION",      unsortedResponse.EventValidation },
                 { "ctl00$searchTextBox",    searchQuery }
             };
 
             var requestContent = new FormUrlEncodedContent(formData); 
 
-            HttpResponseMessage response = await _client.PostAsync(unsortedResponse._searchQueryUri, requestContent, cancellationToken);
+            HttpResponseMessage response = await _client.PostAsync(unsortedResponse.SearchQueryUri, requestContent, cancellationToken);
             response.EnsureSuccessStatusCode();
             
             var HtmlDoc = new HtmlDocument();
             HtmlDoc.Load(await response.Content.ReadAsStreamAsync());
 
-            return _catalogParser.ParseSearchResultsPage(HtmlDoc, unsortedResponse._searchQueryUri);
+            return _catalogParser.ParseSearchResultsPage(HtmlDoc, unsortedResponse.SearchQueryUri);
         }
 
         private async Task<CatalogResponse> InternalSendSearchQueryAsync(string requestUri, CancellationToken cancellationToken)

--- a/Poushec.UpdateCatalogParser/CatalogParser.cs
+++ b/Poushec.UpdateCatalogParser/CatalogParser.cs
@@ -165,15 +165,12 @@ namespace Poushec.UpdateCatalogParser
 
         public CatalogResponse ParseSearchResultsPage(HtmlDocument htmlDoc, string searchQueryUri)
         {
-            string eventArgument = htmlDoc.GetElementbyId("__EVENTARGUMENT")?.FirstChild?.Attributes["value"]?.Value ?? string.Empty;
-            string eventValidation = htmlDoc.GetElementbyId("__EVENTVALIDATION").GetAttributes().Where(att => att.Name == "value").First().Value;
-            string viewState = htmlDoc.GetElementbyId("__VIEWSTATE").GetAttributes().Where(att => att.Name == "value").First().Value;
-            string viewStateGenerator = htmlDoc.GetElementbyId("__VIEWSTATEGENERATOR").GetAttributes().Where(att => att.Name == "value").First().Value;
             bool finalPage = htmlDoc.GetElementbyId("ctl00_catalogBody_nextPageLinkText") is null;
 
             string resultsCountString = htmlDoc.GetElementbyId("ctl00_catalogBody_searchDuration").InnerText;
             int resultsCount = int.Parse(Regex.Match(resultsCountString, "(?<=of )\\d{1,4}").Value);
             int currentPage = int.Parse(Regex.Match(resultsCountString, "(?<=page\\s)\\d{1,2}(?=\\sof\\s\\d{1,2})").Value);
+            currentPage--;
 
             HtmlNode table = htmlDoc.GetElementbyId("ctl00_catalogBody_updateMatches");
 
@@ -192,10 +189,7 @@ namespace Poushec.UpdateCatalogParser
             return new CatalogResponse(
                 searchQueryUri,
                 searchResults,
-                eventArgument,
-                eventValidation,
-                viewState,
-                viewStateGenerator,
+                resultsCount,
                 currentPage
             );
         }

--- a/Poushec.UpdateCatalogParser/CatalogParser.cs
+++ b/Poushec.UpdateCatalogParser/CatalogParser.cs
@@ -173,6 +173,7 @@ namespace Poushec.UpdateCatalogParser
 
             string resultsCountString = htmlDoc.GetElementbyId("ctl00_catalogBody_searchDuration").InnerText;
             int resultsCount = int.Parse(Regex.Match(resultsCountString, "(?<=of )\\d{1,4}").Value);
+            int currentPage = int.Parse(Regex.Match(resultsCountString, "(?<=page\\s)\\d{1,2}(?=\\sof\\s\\d{1,2})").Value);
 
             HtmlNode table = htmlDoc.GetElementbyId("ctl00_catalogBody_updateMatches");
 
@@ -185,7 +186,7 @@ namespace Poushec.UpdateCatalogParser
 
             List<CatalogSearchResult> searchResults = searchResultsRows
                 .Skip(1) // First row is always a headerRow
-                .Select(resultsRow => ParseResultsTableRow(resultsRow))
+                .Select(ParseResultsTableRow)
                 .ToList();
 
             return new CatalogResponse(
@@ -195,8 +196,7 @@ namespace Poushec.UpdateCatalogParser
                 eventValidation,
                 viewState,
                 viewStateGenerator,
-                finalPage,
-                resultsCount
+                currentPage
             );
         }
 

--- a/Poushec.UpdateCatalogParser/Models/CatalogResponce.cs
+++ b/Poushec.UpdateCatalogParser/Models/CatalogResponce.cs
@@ -12,10 +12,11 @@ namespace Poushec.UpdateCatalogParser.Models
         internal string ViewStateGenerator;
 
         internal int TotalPages => (int)Math.Ceiling((double)ResultsCount / 25);
+        internal readonly int CurrentPage;
 
-        public readonly bool FinalPage;
+        public bool FinalPage => CurrentPage == TotalPages;
         public List<CatalogSearchResult> SearchResults;
-        public int ResultsCount;
+        public int ResultsCount => SearchResults.Count;
 
         internal CatalogResponse(
             string searchQueryUri,
@@ -24,8 +25,7 @@ namespace Poushec.UpdateCatalogParser.Models
             string eventValidation,
             string viewState,
             string viewStateGenerator,
-            bool finalPage,
-            int resultsCount
+            int currentPage
         ) 
         {
             SearchQueryUri = searchQueryUri;
@@ -35,9 +35,7 @@ namespace Poushec.UpdateCatalogParser.Models
             this.EventValidation = eventValidation;
             this.ViewState = viewState;
             this.ViewStateGenerator = viewStateGenerator;
-            this.FinalPage = finalPage;
-
-            this.ResultsCount = resultsCount;
+            this.CurrentPage = currentPage;
         }
     }
 }

--- a/Poushec.UpdateCatalogParser/Models/CatalogResponce.cs
+++ b/Poushec.UpdateCatalogParser/Models/CatalogResponce.cs
@@ -6,35 +6,26 @@ namespace Poushec.UpdateCatalogParser.Models
     public class CatalogResponse
     {
         internal string SearchQueryUri;
-        internal string EventArgument;
-        internal string EventValidation;
-        internal string ViewState;
-        internal string ViewStateGenerator;
 
-        internal int TotalPages => (int)Math.Ceiling((double)ResultsCount / 25);
+        internal int TotalPages => (int)Math.Ceiling((double)ResultsCount / 25) - 1; 
         internal readonly int CurrentPage;
+        internal string SortQuery = string.Empty; 
 
         public bool FinalPage => CurrentPage == TotalPages;
         public List<CatalogSearchResult> SearchResults;
-        public int ResultsCount => SearchResults.Count;
+        public readonly int ResultsCount;
 
         internal CatalogResponse(
             string searchQueryUri,
             List<CatalogSearchResult> searchResults, 
-            string eventArgument, 
-            string eventValidation,
-            string viewState,
-            string viewStateGenerator,
+            int resultsCount,
             int currentPage
         ) 
         {
             SearchQueryUri = searchQueryUri;
 
             this.SearchResults = searchResults;
-            this.EventArgument = eventArgument;
-            this.EventValidation = eventValidation;
-            this.ViewState = viewState;
-            this.ViewStateGenerator = viewStateGenerator;
+            this.ResultsCount = resultsCount;
             this.CurrentPage = currentPage;
         }
     }

--- a/Poushec.UpdateCatalogParser/Models/CatalogResponce.cs
+++ b/Poushec.UpdateCatalogParser/Models/CatalogResponce.cs
@@ -1,14 +1,17 @@
+using System;
 using System.Collections.Generic;
 
 namespace Poushec.UpdateCatalogParser.Models
 {
     public class CatalogResponse
     {
-        internal string _searchQueryUri;
-        internal string _eventArgument;
-        internal string _eventValidation;
-        internal string _viewState;
-        internal string _viewStateGenerator;
+        internal string SearchQueryUri;
+        internal string EventArgument;
+        internal string EventValidation;
+        internal string ViewState;
+        internal string ViewStateGenerator;
+
+        internal int TotalPages => (int)Math.Ceiling((double)ResultsCount / 25);
 
         public readonly bool FinalPage;
         public List<CatalogSearchResult> SearchResults;
@@ -25,13 +28,13 @@ namespace Poushec.UpdateCatalogParser.Models
             int resultsCount
         ) 
         {
-            _searchQueryUri = searchQueryUri;
+            SearchQueryUri = searchQueryUri;
 
             this.SearchResults = searchResults;
-            this._eventArgument = eventArgument;
-            this._eventValidation = eventValidation;
-            this._viewState = viewState;
-            this._viewStateGenerator = viewStateGenerator;
+            this.EventArgument = eventArgument;
+            this.EventValidation = eventValidation;
+            this.ViewState = viewState;
+            this.ViewStateGenerator = viewStateGenerator;
             this.FinalPage = finalPage;
 
             this.ResultsCount = resultsCount;

--- a/Poushec.UpdateCatalogParser/Poushec.UpdateCatalogParser.csproj
+++ b/Poushec.UpdateCatalogParser/Poushec.UpdateCatalogParser.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.62" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poushec.UpdateCatalogParser/Poushec.UpdateCatalogParser.csproj
+++ b/Poushec.UpdateCatalogParser/Poushec.UpdateCatalogParser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Poushec.UpdateCatalogParser</PackageId>
-    <Version>4.0.3</Version>
+    <Version>4.1.0</Version>
     <Authors>Poushec</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This PR updates the library to support the updated navigation format introduced by Microsoft. It eliminates the need to send separate requests for search result sorting, as well as the need to store variables like __EVENTVALIDATION, __VIEWSTATE, etc.

Closes #13 