### PR TITLE
Fix: Size in bytes property type

### DIFF
--- a/Poushec.UpdateCatalogParser/CatalogParser.cs
+++ b/Poushec.UpdateCatalogParser/CatalogParser.cs
@@ -204,7 +204,7 @@ namespace Poushec.UpdateCatalogParser
             DateTime lastUpdated = DateTime.Parse(rowCells[4].InnerText.Trim(), _cultureInfo);
             string version = rowCells[5].InnerText.Trim();
             string size = rowCells[6].SelectNodes("span")[0].InnerText;
-            int sizeInBytes = int.Parse(rowCells[6].SelectNodes("span")[1].InnerHtml);
+            long sizeInBytes = long.Parse(rowCells[6].SelectNodes("span")[1].InnerHtml);
             string updateID = rowCells[7].SelectNodes("input")[0].Id;
 
             return new CatalogSearchResult(title, products, classification, lastUpdated, version, size, sizeInBytes, updateID);

--- a/Poushec.UpdateCatalogParser/Models/CatalogSearchResult.cs
+++ b/Poushec.UpdateCatalogParser/Models/CatalogSearchResult.cs
@@ -1,4 +1,3 @@
-using HtmlAgilityPack;
 using System;
 
 namespace Poushec.UpdateCatalogParser.Models
@@ -11,7 +10,7 @@ namespace Poushec.UpdateCatalogParser.Models
         public DateTime LastUpdated { get; set; }
         public string Version { get; set; }
         public string Size { get; set; }
-        public int SizeInBytes { get; set; }
+        public long SizeInBytes { get; set; }
         public string UpdateID { get; set; }
 
         internal CatalogSearchResult(
@@ -21,7 +20,7 @@ namespace Poushec.UpdateCatalogParser.Models
             DateTime lastUpdated, 
             string version, 
             string size, 
-            int sizeInBytes, 
+            long sizeInBytes, 
             string updateId) 
         {
             this.Title = title;

--- a/Poushec.UpdateCatalogParser/Poushec.UpdateCatalogParser.csproj
+++ b/Poushec.UpdateCatalogParser/Poushec.UpdateCatalogParser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Poushec.UpdateCatalogParser</PackageId>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <Authors>Poushec</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/UpdateCatalogParser.Tests/CatalogSearchTest.cs
+++ b/UpdateCatalogParser.Tests/CatalogSearchTest.cs
@@ -20,6 +20,17 @@ namespace UpdateCatalogParser.Tests
             Assert.Equal(49, searchResults.Count);
         }
 
+        [Trait("Catalog Search", "Large Update Files Test")]
+        [Theory(DisplayName = "Query that returns an update with filesize exiding the int limitation runs successfully")]
+        [InlineData("KB5060842")]
+        public async Task Send_Search_Query_For_Update_With_Large_Source_Runs_Successfully(string searchQuery)
+        {
+            var catalogClient = new CatalogClient();
+            List<CatalogSearchResult> searchResults = await catalogClient.SendSearchQueryAsync(searchQuery);
+
+            Assert.NotNull(searchResults);
+        }
+
         [Trait("Catalog Search", "Tests for Catalog Search queries")]
         [Theory(DisplayName = "GetFirstPageFromSearchQueryAsync Returns Correct Results Count ")]
         [InlineData("SQL Server 2012")] 


### PR DESCRIPTION
This PR fixes #15 issue by changing the SizeInBytes property type to long instead of int, as some of the updates exceed the int max value